### PR TITLE
feat(ci): Auto-update Homebrew formula SHA256 on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,37 @@ jobs:
           cd build && tar czf droidtether-darwin-arm64.tar.gz droidtether
           shasum -a 256 droidtether-darwin-arm64.tar.gz > droidtether-darwin-arm64.tar.gz.sha256
 
+      - name: Calculate SHA256 hashes
+        id: sha256
+        run: |
+          # Extract SHA256 for arm64
+          ARM64_SHA256=$(cut -d' ' -f1 build/droidtether-darwin-arm64.tar.gz.sha256)
+          echo "arm64_sha256=${ARM64_SHA256}" >> $GITHUB_OUTPUT
+          echo "ARM64 SHA256: ${ARM64_SHA256}"
+
+      - name: Update Homebrew Formula
+        run: |
+          # Get version from tag (remove 'v' prefix)
+          VERSION="${GITHUB_REF_NAME#v}"
+          
+          # Update version in formula
+          sed -i '' "s/version \".*\"/version \"${VERSION}\"/" Formula/droidtether.rb
+          
+          # Update SHA256 for arm64
+          sed -i '' "s/sha256 \"REPLACE_WITH_ACTUAL_SHA256_AFTER_RELEASE\"/sha256 \"${{ steps.sha256.outputs.arm64_sha256 }}\"/" Formula/droidtether.rb
+          
+          echo "Updated Formula with:"
+          echo "  Version: ${VERSION}"
+          echo "  ARM64 SHA256: ${{ steps.sha256.outputs.arm64_sha256 }}"
+
+      - name: Commit updated Formula
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/droidtether.rb
+          git commit -m "chore: update Homebrew formula for ${{ github.ref_name }}"
+          git push
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/Formula/droidtether.rb
+++ b/Formula/droidtether.rb
@@ -1,17 +1,17 @@
 class DroidTether < Formula
     desc "Android USB tethering for Apple Silicon Macs — no kext, no SIP changes"
-    homepage "https://github.com/princePal/droidtether"
+    homepage "https://github.com/HelloPrincePal/DroidTether"
     version "1.0.0"
   
     # ARM binary (Apple Silicon — M1/M2/M3/M4)
     on_arm do
-      url "https://github.com/princePal/droidtether/releases/download/v#{version}/droidtether-darwin-arm64.tar.gz"
+      url "https://github.com/HelloPrincePal/DroidTether/releases/download/v#{version}/droidtether-darwin-arm64.tar.gz"
       sha256 "REPLACE_WITH_ACTUAL_SHA256_AFTER_RELEASE"
     end
   
     # Intel binary (fallback)
     on_intel do
-      url "https://github.com/princePal/droidtether/releases/download/v#{version}/droidtether-darwin-amd64.tar.gz"
+      url "https://github.com/HelloPrincePal/DroidTether/releases/download/v#{version}/droidtether-darwin-amd64.tar.gz"
       sha256 "REPLACE_WITH_ACTUAL_SHA256_AFTER_RELEASE"
     end
   
@@ -61,7 +61,7 @@ class DroidTether < Formula
           sudo launchctl unload /Library/LaunchDaemons/com.princePal.droidtether.plist
           sudo launchctl load /Library/LaunchDaemons/com.princePal.droidtether.plist
   
-        GitHub: https://github.com/princePal/droidtether
+        GitHub: https://github.com/HelloPrincePal/DroidTether
       EOS
     end
   
@@ -112,7 +112,7 @@ class DroidTether < Formula
       # Embedded minimal default config (full reference: repo config/default.toml)
       <<~TOML
         # DroidTether config — edit as needed
-        # Full reference: https://github.com/princePal/droidtether/blob/main/config/default.toml
+        # Full reference: https://github.com/HelloPrincePal/DroidTether/blob/main/config/default.toml
   
         [usb]
         poll_interval_ms = 500


### PR DESCRIPTION
## Summary

This PR implements CI/CD automation for the Homebrew Tap, automatically updating the SHA256 hash in the formula when a new release is published.

## Changes

### 1. Enhanced Release Workflow (\.github/workflows/release.yml\)
- Added \Calculate SHA256 hashes\ step to extract the hash from the built binary
- Added \Update Homebrew Formula\ step that uses \sed\ to update \Formula/droidtether.rb\
- Added \Commit updated Formula\ step to push the changes back to the repo

### 2. Fixed Repository URLs in Formula (\Formula/droidtether.rb\)
- Corrected URLs from \princePal/droidtether\ to \HelloPrincePal/DroidTether\
- This ensures the formula can actually download the binaries from the correct release

## How It Works

1. When a new tag (v*) is pushed, the release workflow triggers
2. The workflow builds the arm64 binary and calculates its SHA256
3. The workflow updates \Formula/droidtether.rb\ with the new version and SHA256
4. The updated formula is committed and pushed to the repo
5. Users can now install via Homebrew: \rew tap HelloPrincePal/DroidTether && brew install droidtether\

## Testing

The workflow can be tested by pushing a new tag. The formula will be automatically updated with the correct SHA256.

## Resolves

Closes #1

---

This is my first contribution to DroidTether! 🎉 Let me know if any changes are needed.